### PR TITLE
Backend: Added logout endpoint

### DIFF
--- a/server/api.yaml
+++ b/server/api.yaml
@@ -74,7 +74,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
+  /auth/logout:
+    post:
+      tags:
+        - auth
+      summary: Logout from the system
+      description: The endpoint removes the session token from the cookies.
+      security:
+        - cookie_token:
+      responses:
+        204:
+          description: successful operation
+        401:
+          description: Not logged in.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /search:
     get:

--- a/server/src/controllers/AuthenticationController.ts
+++ b/server/src/controllers/AuthenticationController.ts
@@ -10,6 +10,7 @@ import { AuthenticatedUser } from "../models/User";
 
 export interface AuthenticationControllerType {
   login(req: Request, res: Response): Promise<void>;
+  logout(req: Request, res: Response): Promise<void>;
   getSession(req: Request, res: Response): Promise<void>;
 }
 
@@ -87,6 +88,11 @@ export class AuthenticationController implements AuthenticationControllerType {
   async getSession(req: Request, res: Response): Promise<void> {
     const user = res.locals.user as AuthenticatedUser;
     res.status(200).json(user);
+  }
+
+  async logout(req: Request, res: Response): Promise<void> {
+    res.clearCookie(TOKEN_COOKIE_NAME);
+    res.status(204).end();
   }
 
   // Check if the google access token has already been used in a previous login

--- a/server/src/routes/AuthenticationRouter.ts
+++ b/server/src/routes/AuthenticationRouter.ts
@@ -18,6 +18,10 @@ export default class AuthenticationRouter implements RouterType {
     const router = Router();
     this.middlewares.forEach(middleware => router.use(middleware.handle.bind(middleware)));
     router.post("/login", this.authenticationController.login.bind(this.authenticationController));
+    router.post("/logout", 
+      this.authMiddleware.handle.bind(this.authMiddleware), 
+      this.authenticationController.logout.bind(this.authenticationController)
+    );
     router.get("/session", 
       this.authMiddleware.handle.bind(this.authMiddleware), 
       this.authenticationController.getSession.bind(this.authenticationController)


### PR DESCRIPTION
The endpoint returns a response header with instruction to delete the session token from the cookie storage