### PR TITLE
Added /cohorts endpoint to API docs

### DIFF
--- a/server/api.yaml
+++ b/server/api.yaml
@@ -15,21 +15,23 @@ servers:
   - url: https://dojo-test.hackyourfuture.net/api/
     description: Test server
 tags:
-  - name: auth
+  - name: Auth
     description: ''
-  - name: search
+  - name: Search
     description: ''
-  - name: trainees
+  - name: Trainees
     description: ''
-  - name: geography
+  - name: Cohorts
     description: ''
-  - name: dashboard
+  - name: Geography
+    description: ''
+  - name: Dashboard
     description: ''
 paths:
   /auth/login:
     post:
       tags:
-        - auth
+        - Auth
       summary: Login to the system
       description: The endpoint exchanges Google OAuth2 token for internal JWT token to be used for authenticated requests
       requestBody:
@@ -60,7 +62,7 @@ paths:
   /auth/session:
     get:
       tags:
-        - auth
+        - Auth
       summary: Get current logged in user info
       description: This endpoint returns the currently authenticated user. It extracts and verifies the session token.
       security:
@@ -81,7 +83,7 @@ paths:
   /auth/logout:
     post:
       tags:
-        - auth
+        - Auth
       summary: Logout from the system
       description: The endpoint removes the session token from the cookies.
       security:
@@ -99,7 +101,7 @@ paths:
   /search:
     get:
       tags:
-        - search
+        - Search
       summary: Find trainees
       description:  Find trainees by a keyword. The search will try to match the first name, last name or email.
       security:
@@ -147,10 +149,11 @@ paths:
 
         '400':
           description: Missing query
+   
   /trainees:
     post:
       tags:
-        - trainees
+        - Trainees
       summary: Create new profile
       description: ''
       security:
@@ -171,7 +174,7 @@ paths:
   /trainees/{id}:
     get:
       tags:
-        - trainees
+        - Trainees
       summary: Fetch information about a trainee
       description: ''
       security:
@@ -200,7 +203,7 @@ paths:
 
     patch:
       tags:
-        - trainees
+        - Trainees
       summary: Update trainee information
       description: ''
       security:
@@ -234,7 +237,7 @@ paths:
                 
     delete:
       tags:
-        - trainees
+        - Trainees
       summary: Delete trainee from the system
       description: ''
       security:
@@ -261,7 +264,7 @@ paths:
   /trainees/{id}/profile-picture:
     get:
       tags:
-        - trainees
+        - Trainees
       summary: Fetch the profile picture of a trainee
       description: ''
       security:
@@ -299,7 +302,7 @@ paths:
 
     put:
       tags:
-        - trainees
+        - Trainees
       summary: Upload new profile picture of a given trainee
       description: > 
        Accepts only images. The new image will override the old image.
@@ -346,7 +349,7 @@ paths:
                 
     delete:
       tags:
-        - trainees
+        - Trainees
       summary: Delete profile picture of a given trainee
       description: ''
       security:
@@ -373,7 +376,7 @@ paths:
   /trainees/{id}/strikes:
     get:
       tags:
-        - trainees
+        - Trainees
       summary: Fetch all strikes of a trainee
       description: ''
       security:
@@ -396,7 +399,7 @@ paths:
                   $ref: '#/components/schemas/StrikeWithReporter'
     post:
       tags:
-        - trainees
+        - Trainees
       summary: Create new strike
       description: ''
       security:
@@ -425,7 +428,7 @@ paths:
   /trainees/{id}/strikes/{strikeID}:
     put:
       tags:
-        - trainees
+        - Trainees
       summary: Update existing strike
       description: ''
       security:
@@ -458,7 +461,7 @@ paths:
                 $ref: '#/components/schemas/StrikeWithReporter'
     delete:
       tags:
-        - trainees
+        - Trainees
       summary: Delete existing strike
       description: ''
       security:
@@ -480,10 +483,76 @@ paths:
         204:
           description: successful operation
 
+  /cohorts:
+    get:
+      tags:
+        - Cohorts
+      summary: Fetch a list of cohorts with their trainees
+      description: Returns a list of cohorts for a specified range.
+      security:
+        - cookie_token:
+      parameters:
+        - name: start
+          in: query
+          description: "Lower range of the cohort. Default: 0"
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 999
+        - name: end
+          in: query
+          description: "Upper range of the cohort. Default: 999"
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 999
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    cohort:
+                      type: number
+                    trainees:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          thumbnailURL:
+                            type: string
+                          displayName:
+                            type: string
+                          location:
+                            type: string
+                          hasWorkPermit:
+                            type: boolean
+                          email:
+                            type: string
+                          slackID:
+                            type: string
+                          githubHandle:
+                            type: string
+                          linkedIn:
+                            type: string
+                          learningStatus:
+                            $ref: '#/components/schemas/LearningStatus'
+                          jobPath:
+                            $ref: '#/components/schemas/JobPath'
+                          strikes:
+                            type: number
+
   /geo/cities:
     get:
       tags:
-        - geography
+        - Geography
       summary: Get list of cities
       description:  Find cities by a keyword. Query and limit variables are optional. This endpoint is useful for auto-complete fields
       security:
@@ -515,7 +584,7 @@ paths:
   /geo/countries:
     get:
       tags:
-        - geography
+        - Geography
       summary: Get list of countries
       description:  Find countries by a keyword. Query and limit variables are optional. This endpoint is useful for auto-complete fields
       security:
@@ -552,7 +621,7 @@ paths:
   /dashboard:
       get:
         tags:
-          - dashboard
+          - Dashboard
         summary: Get the data to display on the dashboard
         description: ''
         security:
@@ -679,7 +748,6 @@ components:
             - woman
             - non-binary
             - other
-          example: male
         pronouns:
           type: string
           example: He/His
@@ -777,13 +845,7 @@ components:
           minimum: 0
           maximum: 999
         learningStatus:
-          type: string
-          enum:
-            - studying
-            - graduated
-            - on-hold
-            - quit
-          example: studying
+          $ref: '#/components/schemas/LearningStatus'
         startDate:
           type: string
           format: date-time
@@ -827,16 +889,7 @@ components:
         - jobPath
       properties:
         jobPath:
-          type: string
-          enum:
-            - not-graduated
-            - searching
-            - internship
-            - tech-job
-            - non-tech-job
-            - not-searching
-            - other-studies
-            - no-longer-helping
+          $ref: '#/components/schemas/JobPath'
         cvURL:
           type: string
           example: https://example.com/cv.pdf
@@ -1035,6 +1088,28 @@ components:
           example: 65ea2e1e696deb3b3ebff843
         details:
           type: string
+
+    LearningStatus:
+      type: string
+      enum:
+        - studying
+        - graduated
+        - on-hold
+        - quit
+      example: studying | graduated | on-hold | quit
+
+    JobPath:
+      type: string
+      enum:
+        - not-graduated
+        - searching
+        - internship
+        - tech-job
+        - non-tech-job
+        - not-searching
+        - other-studies
+        - no-longer-helping
+      example: not-graduated
 
     User:
       type: object


### PR DESCRIPTION
Also minor fixes in the docs:

- Capitalization for tags
- Extract LearningStatus and JobPath enums to reuse them in multiple endpoint schemas

<img width="790" alt="image" src="https://github.com/user-attachments/assets/df60a25d-a13d-4f58-be8f-7e50e4a155f8">

<img width="790" alt="image" src="https://github.com/user-attachments/assets/47c4457b-b143-462e-9435-337894f7820b">

