### PR TITLE
[2/3] Added IP Geolocation repository

### DIFF
--- a/server/src/models/IPGeolocation.ts
+++ b/server/src/models/IPGeolocation.ts
@@ -1,0 +1,11 @@
+import { Country } from './Country';
+
+export interface IPGeolocation {
+  ip: string;
+  country: Country;
+}
+
+export interface DBIPGeolocation {
+  ip: string;
+  countryCode: string;
+}

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -5,3 +5,4 @@ export * from './User';
 export * from './City';
 export * from './Country';
 export * from './Strike';
+export * from './IPGeolocation';

--- a/server/src/repositories/IPGeolocationRepository.ts
+++ b/server/src/repositories/IPGeolocationRepository.ts
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+import { DBIPGeolocation, IPGeolocation } from '../models';
+import { IPGeolocationSchema } from '../schemas';
+
+export interface IPGeolocationRepository {
+  setIP(ip: string, countryCode: string): Promise<void>;
+  findIP(ip: string): Promise<IPGeolocation | null>;
+}
+
+export class MongooseIPGeolocationRepository implements IPGeolocationRepository {
+  private IPGeolocationModel: mongoose.Model<DBIPGeolocation>;
+
+  constructor(db: mongoose.Connection) {
+    this.IPGeolocationModel = db.model<DBIPGeolocation>('IPGeolocation', IPGeolocationSchema);
+  }
+
+  async setIP(ip: string, countryCode: string): Promise<void> {
+    await this.IPGeolocationModel.findOneAndUpdate({ ip }, { countryCode }, { upsert: true });
+  }
+
+  async findIP(ip: string): Promise<IPGeolocation | null> {
+    const result = await this.IPGeolocationModel.findOne<IPGeolocation>({ ip }).populate('countryCode').exec();
+    if (!result) {
+      return null;
+    }
+    return {
+      ip: result.ip,
+      country: result.country,
+    };
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -2,3 +2,4 @@ export * from './TokenRepository';
 export * from './UserRepository';
 export * from './TraineesRepository';
 export * from './GeographyRepository';
+export * from './IPGeolocationRepository';

--- a/server/src/schemas/IPGeolocationSchema.ts
+++ b/server/src/schemas/IPGeolocationSchema.ts
@@ -1,0 +1,13 @@
+import { Schema } from 'mongoose';
+import { DBIPGeolocation } from '../models';
+import { jsonFormatting } from '../utils/database';
+
+const IPGeolocationSchema: Schema = new Schema<DBIPGeolocation>({
+  ip: { type: String, required: true, unique: true, index: true },
+  countryCode: { type: String, required: true, ref: 'Country', alias: 'country', regex: /^[A-Z]{2}$/ },
+});
+
+IPGeolocationSchema.set('toJSON', jsonFormatting);
+IPGeolocationSchema.set('toObject', jsonFormatting);
+
+export { IPGeolocationSchema };

--- a/server/src/schemas/index.ts
+++ b/server/src/schemas/index.ts
@@ -3,3 +3,4 @@ export * from './UserSchema';
 export * from './TraineeSchema';
 export * from './CitySchema';
 export * from './CountrySchema';
+export * from './IPGeolocationSchema';


### PR DESCRIPTION
This will be used For caching IP address geolocations in the database to avoid querying the external API too much

Implements to #173 