### PR TITLE
API docs: Fixed the reporter in trainee interactions schema

### DIFF
--- a/server/api.yaml
+++ b/server/api.yaml
@@ -867,7 +867,7 @@ components:
         interactions:
           type: array
           items:
-            $ref: '#/components/schemas/TraineeInteraction'
+            $ref: '#/components/schemas/InteractionWithReporter'
           
     TraineePersonalInfo:
       type: object


### PR DESCRIPTION
Part of the GET /trainee/:id endpoint is now correct:
![image](https://github.com/user-attachments/assets/e2886e91-d76f-437d-bd00-286ef73607bb)
