### PR TITLE
Added lazy loading for profile images in the cohorts page.

### DIFF
--- a/client/src/components/cohorts/CohortAccordion.tsx
+++ b/client/src/components/cohorts/CohortAccordion.tsx
@@ -7,16 +7,16 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import EmailIcon from '@mui/icons-material/EmailOutlined';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
+import { TraineeAvatar } from '../cohorts/TraineeAvatar';
 
 import { useNavigate } from 'react-router-dom';
-import { Cohort, LearningStatus } from '../models';
-import { SidebarJobPath, SidebarLearningStatus } from '.';
-import slackLogo from '../assets/slack.png';
+import { Cohort, LearningStatus } from '../../models';
+import { SidebarJobPath, SidebarLearningStatus } from '..';
+import slackLogo from '../../assets/slack.png';
 
 export interface CohortAccordionProps {
   cohortInfo: Cohort;
@@ -71,11 +71,7 @@ export const CohortAccordion = ({ cohortInfo }: CohortAccordionProps) => {
                   onClick={() => navigate(`/trainee/${trainee.displayName.replace(/ /g, '-')}_${trainee.id}`)}
                 >
                   <TableCell component="th" scope="row">
-                    <Avatar
-                      alt={trainee.displayName}
-                      src={trainee.thumbnailURL ? trainee.thumbnailURL : undefined}
-                      variant="square"
-                    />
+                    <TraineeAvatar imageURL={trainee.thumbnailURL ?? ''} altText={trainee.displayName}></TraineeAvatar>
                   </TableCell>
                   <TableCell>{trainee.displayName}</TableCell>
                   <TableCell sx={{ whiteSpace: 'nowrap' }}>

--- a/client/src/components/cohorts/TraineeAvatar.tsx
+++ b/client/src/components/cohorts/TraineeAvatar.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Skeleton, Avatar } from '@mui/material';
+
+export interface TraineeAvatarProps {
+  imageURL: string;
+  altText: string;
+}
+
+export const TraineeAvatar = ({ imageURL, altText }: TraineeAvatarProps) => {
+  const size = { width: 40, height: 40 };
+  const [isError, setIsError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  if (isError) {
+    return <Avatar sx={size} alt={altText} variant="square"></Avatar>;
+  }
+
+  return (
+    <>
+      {isLoading && <Skeleton variant="rectangular" width={size.width} height={size.height} />}
+      <img
+        loading="lazy"
+        src={imageURL}
+        alt={altText}
+        style={{
+          width: `${isLoading ? 0 : size.width}px`,
+          height: `${isLoading ? 0 : size.height}px`,
+          display: isLoading ? 'block' : 'block',
+        }}
+        onError={() => {
+          setIsLoading(false);
+          setIsError(true);
+        }}
+        onLoad={() => setIsLoading(false)}
+      />
+    </>
+  );
+};

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,4 +1,4 @@
-export * from './CohortAccordion';
+export * from './cohorts/CohortAccordion';
 export * from './Comment';
 export * from './ContactInfo';
 export * from './InteractionsInfo';


### PR DESCRIPTION
**The issue:**
When navigating to the cohorts page, all avatar images are being loaded immediately. This causes to load 500+ images simultaneously which makes the browser lag and unnecessary overloads the server. 

**The solution:**
MUI's Avatar component does not support lazy loading images. So I had to use the plain `img` tag with the new lazy property. And as a bonus I also added a nice gray loading indicator while the image is being loaded