### PR TITLE
Change trainee image upload to use S3 bucket URL directly

### DIFF
--- a/client/src/components/ProfileSidebar.tsx
+++ b/client/src/components/ProfileSidebar.tsx
@@ -45,12 +45,7 @@ export const ProfileSidebar = ({ traineeId }: ProfileSidebarProps) => {
     >
       {/* Profile image */}
       <Box height={180} width={180} display="flex" justifyContent="center">
-        <Avatar
-          variant="square"
-          sx={{ width: '100%', height: '100%' }}
-          src={data?.personalInfo?.imageUrl}
-          alt={data?.displayName}
-        />
+        <Avatar variant="square" sx={{ width: '100%', height: '100%' }} src={data?.imageURL} alt={data?.displayName} />
       </Box>
 
       <Stack direction="column" spacing={1} justifyContent="center" alignItems="center">

--- a/client/src/components/education/StrikesList.tsx
+++ b/client/src/components/education/StrikesList.tsx
@@ -12,7 +12,6 @@ import {
 
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import { Strike } from '../../models';
 import { formatDateForDisplay } from '../../helpers/dateHelper';
 
@@ -89,9 +88,7 @@ export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, 
                   }}
                 >
                   <Tooltip title={strike.reporter.name} placement="top">
-                    <Avatar src={strike.reporter.imageUrl}>
-                      <HighlightOffIcon />
-                    </Avatar>
+                    <Avatar src={strike.reporter.imageUrl}></Avatar>
                   </Tooltip>
                 </ListItemAvatar>
                 <ListItemText

--- a/client/src/models/Trainee.ts
+++ b/client/src/models/Trainee.ts
@@ -110,6 +110,8 @@ export interface Trainee {
   readonly createdAt: Date;
   readonly updatedAt: Date;
   displayName: string;
+  imageURL?: string;
+  thumbnailURL?: string;
   personalInfo: TraineePersonalInfo;
   contactInfo: TraineeContactInfo;
   educationInfo: TraineeEducationInfo;
@@ -121,7 +123,6 @@ export interface TraineePersonalInfo {
   firstName: string;
   lastName: string;
   preferredName?: string;
-  imageUrl?: string;
   gender: Gender;
   pronouns?: string;
   location?: string;

--- a/server/.env.example
+++ b/server/.env.example
@@ -10,11 +10,12 @@ GOOGLE_OAUTH_CLIENTID=xxxxx.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENTSECRET=secret
 
 # S3 storage
-STORAGE_ENDPOINT="https://s3.us-east-005.backblazeb2.com"
-STORAGE_REGION="us-east-005"
-STORAGE_BUCKET="hyf-dojo-test"
+STORAGE_ENDPOINT="https://ams3.digitaloceanspaces.com"
+STORAGE_REGION="ams3"
+STORAGE_BUCKET="dojo-test"
 STORAGE_ACCESS_KEY_ID="<Access key ID>"
 STORAGE_ACCESS_KEY_SECRET="<Secret key>"
+STORAGE_BASE_URL="https://dojo-test.ams3.cdn.digitaloceanspaces.com"
 
 # Sentry config
 SENTRY_AUTH_TOKEN=secret

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -264,44 +264,6 @@ paths:
                 $ref: '#/components/schemas/Error'
 
   /trainees/{id}/profile-picture:
-    get:
-      tags:
-        - Trainees
-      summary: Fetch the profile picture of a trainee
-      description: ''
-      security:
-        - cookie_token:
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-            example: "3jvz35Z"
-        - name: size
-          in: query
-          description: Fetch a different size of the image.
-          required: false
-          schema:
-            type: string
-            enum:
-            - small
-          
-          
-      responses:
-        '200':
-          description: successful operation
-          content:
-            image/png:
-              schema:
-                $ref: '#/components/schemas/Binary'
-        '404':
-          description: Trainee was not found or image was not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
     put:
       tags:
         - Trainees
@@ -339,9 +301,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  imageUrl:
+                  imageURL:
                     type: string
-                    example: 'https://example.cpm/trainee/65e9c0d25cd76173a4e431c2/profile-picture'
+                    example: 'https://example.com/image/65e9c0d25cd76173a4e431c.jpeg'
+                  thumbnailURL:
+                      type: string
+                      example: 'https://example.com/image/65e9c0d25cd76173a4e431c_thumbnail.jpeg'
         '404':
           description: Trainee was not found
           content:

--- a/server/src/controllers/CohortsController.ts
+++ b/server/src/controllers/CohortsController.ts
@@ -60,11 +60,10 @@ export class CohortsController implements CohortsControllerType {
   }
 
   private getTraineeSummary(trainee: Trainee): TraineeSummary {
-    const thumbnailURL = trainee.personalInfo.imageUrl ? `${trainee.personalInfo.imageUrl}?size=small` : null;
     return {
       id: trainee.id,
       displayName: trainee.displayName,
-      thumbnailURL: thumbnailURL,
+      thumbnailURL: trainee.thumbnailURL ?? null,
       location: trainee.personalInfo.location,
       hasWorkPermit: trainee.personalInfo.hasWorkPermit,
       email: trainee.contactInfo.email,

--- a/server/src/controllers/SearchController.ts
+++ b/server/src/controllers/SearchController.ts
@@ -76,7 +76,7 @@ export class SearchController implements SearchControllerType {
         return {
           id: trainee.id,
           name: `${trainee.displayName}`,
-          thumbnail: trainee.personalInfo.imageUrl ? `${trainee.personalInfo.imageUrl}?size=small` : null,
+          thumbnail: trainee.thumbnailURL ?? null,
           cohort: trainee.educationInfo.currentCohort ?? null,
           searchScore: this.calculateScore(trainee, keywords),
         };

--- a/server/src/controllers/Trainee/ProfilePictureController.ts
+++ b/server/src/controllers/Trainee/ProfilePictureController.ts
@@ -1,0 +1,141 @@
+import { Request, Response, NextFunction } from 'express';
+import { TraineesRepository } from '../../repositories';
+import {
+  StorageServiceType,
+  UploadServiceType,
+  UploadServiceError,
+  ImageServiceType,
+  AccessControl,
+} from '../../services';
+import { ResponseError } from '../../models';
+import * as Sentry from '@sentry/node';
+import fs from 'fs';
+
+export interface ProfilePictureControllerType {
+  setProfilePicture(req: Request, res: Response, next: NextFunction): Promise<void>;
+  deleteProfilePicture(req: Request, res: Response, next: NextFunction): Promise<void>;
+}
+
+export class ProfilePictureController implements ProfilePictureControllerType {
+  private readonly traineesRepository: TraineesRepository;
+  private readonly storageService: StorageServiceType;
+  private readonly uploadService: UploadServiceType;
+  private readonly imageService: ImageServiceType;
+  constructor(
+    traineesRepository: TraineesRepository,
+    storageService: StorageServiceType,
+    uploadService: UploadServiceType,
+    imageService: ImageServiceType
+  ) {
+    this.traineesRepository = traineesRepository;
+    this.storageService = storageService;
+    this.uploadService = uploadService;
+    this.imageService = imageService;
+  }
+
+  async setProfilePicture(req: Request, res: Response, next: NextFunction) {
+    const trainee = await this.traineesRepository.getTrainee(req.params.id);
+    if (!trainee) {
+      res.status(404).send(new ResponseError('Trainee not found'));
+      return;
+    }
+
+    // Handle file upload.
+    try {
+      await this.uploadService.uploadImage(req, res, 'profilePicture');
+    } catch (error: any) {
+      if (error instanceof UploadServiceError) {
+        res.status(400).send(new ResponseError(error.message));
+      } else {
+        next(error);
+      }
+      return;
+    }
+    if (!req.file?.path) {
+      res.status(400).send(new ResponseError('No file was uploaded'));
+      return;
+    }
+
+    // Resize image to reduce file size and create a smaller version
+    const originalFilePath = req.file.path;
+    const largeFilePath = originalFilePath + '_large';
+    const smallFilePath = originalFilePath + '_small';
+    try {
+      await this.imageService.resizeImage(originalFilePath, largeFilePath, 700, 700);
+      await this.imageService.resizeImage(largeFilePath, smallFilePath, 70, 70);
+    } catch (error: any) {
+      next(error);
+      return;
+    }
+
+    // Upload image to storage
+    const baseURL = process.env.STORAGE_BASE_URL ?? '';
+    const imageURL = new URL(this.getImageKey(trainee.id), baseURL).href;
+    const thumbnailURL = new URL(this.getThumbnailKey(trainee.id), baseURL).href;
+
+    try {
+      // Upload images to storage
+      const largeFileStream = fs.createReadStream(largeFilePath);
+      const smallFileStream = fs.createReadStream(smallFilePath);
+      await this.storageService.upload(this.getImageKey(trainee.id), largeFileStream, AccessControl.Public);
+      await this.storageService.upload(this.getThumbnailKey(trainee.id), smallFileStream, AccessControl.Public);
+
+      // update the trainee object with the new image URL
+      trainee.imageURL = imageURL;
+      trainee.thumbnailURL = thumbnailURL;
+      this.traineesRepository.updateTrainee(trainee);
+    } catch (error: any) {
+      next(error);
+      return;
+    }
+
+    // Cleanup
+    fs.unlink(originalFilePath, (error) => {
+      if (error) {
+        Sentry.captureException(error);
+      }
+    });
+    fs.unlink(largeFilePath, (error) => {
+      if (error) {
+        Sentry.captureException(error);
+      }
+    });
+    fs.unlink(smallFilePath, (error) => {
+      if (error) {
+        Sentry.captureException(error);
+      }
+    });
+
+    res.status(201).send({ imageURL, thumbnailURL });
+  }
+
+  async deleteProfilePicture(req: Request, res: Response, next: NextFunction) {
+    const trainee = await this.traineesRepository.getTrainee(req.params.id);
+    if (!trainee) {
+      res.status(404).send(new ResponseError('Trainee not found'));
+      return;
+    }
+    try {
+      await this.storageService.delete(this.getImageKey(trainee.id));
+      await this.storageService.delete(this.getThumbnailKey(trainee.id));
+
+      // update the trainee object with the new image URL
+      trainee.imageURL = undefined;
+      trainee.thumbnailURL = undefined;
+      this.traineesRepository.updateTrainee(trainee);
+    } catch (error: any) {
+      next(error);
+      return;
+    }
+
+    res.status(204).end();
+  }
+
+  private getImageKey(traineeId: string) {
+    return `images/profile/${traineeId}.jpeg`;
+  }
+
+  private getThumbnailKey(traineeId: string) {
+    return `images/profile/${traineeId}_thumb.jpeg`;
+  }
+}

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -3,6 +3,7 @@ export * from './SearchController';
 export * from './Trainee/TraineeController';
 export * from './Trainee/InteractionController';
 export * from './Trainee/TestController';
+export * from './Trainee/ProfilePictureController';
 export * from './GeographyController';
 export * from './DashboardController';
 export * from './CohortsController';

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import {
   DashboardController,
   CohortsController,
   TestController,
+  ProfilePictureController,
 } from './controllers';
 import { MongooseTraineesRepository, MongooseUserRepository, MongooseGeographyRepository } from './repositories';
 import { GoogleOAuthService, TokenService, StorageService, UploadService, ImageService } from './services';
@@ -50,7 +51,7 @@ class Main {
         contentSecurityPolicy: {
           directives: {
             'script-src': ["'self'", 'https://accounts.google.com'],
-            'img-src': ["'self'", 'data:', 'http://*.hackyourfuture.net'],
+            'img-src': ["'self'", 'data:', 'http://*.hackyourfuture.net', process.env.STORAGE_BASE_URL ?? ''],
           },
         },
         crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
@@ -93,7 +94,13 @@ class Main {
       tokenService,
       tokenExpirationInDays
     );
-    const traineeController = new TraineeController(traineesRepository, storageService, uploadService, imageService);
+    const traineeController = new TraineeController(traineesRepository);
+    const profilePictureController = new ProfilePictureController(
+      traineesRepository,
+      storageService,
+      uploadService,
+      imageService
+    );
     const interactionController = new InteractionController(traineesRepository);
     const testController = new TestController();
     const searchController = new SearchController(traineesRepository);
@@ -106,9 +113,13 @@ class Main {
 
     // Setup routers
     const authenticationRouter = new AuthenticationRouter(authenticationController, authMiddleware);
-    const traineeRouter = new TraineesRouter(traineeController, interactionController, testController, [
-      authMiddleware,
-    ]);
+    const traineeRouter = new TraineesRouter(
+      traineeController,
+      interactionController,
+      testController,
+      profilePictureController,
+      [authMiddleware]
+    );
     const searchRouter = new SearchRouter(searchController, [authMiddleware]);
     const geographyRouter = new GeographyRouter(geographyController, [authMiddleware]);
     const dashboardRouter = new DashboardRouter(dashboardController, [authMiddleware]);

--- a/server/src/models/Trainee.ts
+++ b/server/src/models/Trainee.ts
@@ -92,6 +92,8 @@ export interface Trainee {
   readonly createdAt: Date;
   readonly updatedAt: Date;
   displayName: string;
+  imageURL?: string;
+  thumbnailURL?: string;
   personalInfo: TraineePersonalInfo;
   contactInfo: TraineeContactInfo;
   educationInfo: TraineeEducationInfo;
@@ -111,7 +113,6 @@ export interface TraineePersonalInfo {
   firstName: string;
   lastName: string;
   preferredName?: string;
-  imageUrl?: string;
   gender: Gender;
   pronouns?: string;
   location?: string;

--- a/server/src/routes/TraineesRouter.ts
+++ b/server/src/routes/TraineesRouter.ts
@@ -1,11 +1,17 @@
 import { Router } from 'express';
 import RouterType from './Router';
-import { TraineeControllerType, InteractionControllerType, TestControllerType } from '../controllers';
+import {
+  TraineeControllerType,
+  InteractionControllerType,
+  TestControllerType,
+  ProfilePictureControllerType,
+} from '../controllers';
 import Middleware from '../middlewares/Middleware';
 
 export class TraineesRouter implements RouterType {
   private readonly traineeController: TraineeControllerType;
   private readonly interactionController: InteractionControllerType;
+  private readonly profilePictureController: ProfilePictureControllerType;
   private readonly testController: TestControllerType;
   private readonly middlewares: Middleware[];
 
@@ -13,11 +19,13 @@ export class TraineesRouter implements RouterType {
     traineesController: TraineeControllerType,
     interactionController: InteractionControllerType,
     testController: TestControllerType,
+    profilePictureController: ProfilePictureControllerType,
     middlewares: Middleware[] = []
   ) {
     this.traineeController = traineesController;
     this.interactionController = interactionController;
     this.testController = testController;
+    this.profilePictureController = profilePictureController;
     this.middlewares = middlewares;
   }
 
@@ -29,9 +37,14 @@ export class TraineesRouter implements RouterType {
     router.patch('/:id', this.traineeController.updateTrainee.bind(this.traineeController));
     router.delete('/:id', this.traineeController.deleteTrainee.bind(this.traineeController));
 
-    router.get('/:id/profile-picture', this.traineeController.getProfilePicture.bind(this.traineeController));
-    router.put('/:id/profile-picture', this.traineeController.setProfilePicture.bind(this.traineeController));
-    router.delete('/:id/profile-picture', this.traineeController.deleteProfilePicture.bind(this.traineeController));
+    router.put(
+      '/:id/profile-picture',
+      this.profilePictureController.setProfilePicture.bind(this.profilePictureController)
+    );
+    router.delete(
+      '/:id/profile-picture',
+      this.profilePictureController.deleteProfilePicture.bind(this.profilePictureController)
+    );
 
     router.get('/:id/strikes', this.traineeController.getStrikes.bind(this.traineeController));
     router.post('/:id/strikes', this.traineeController.addStrike.bind(this.traineeController));

--- a/server/src/schemas/TraineeSchema.ts
+++ b/server/src/schemas/TraineeSchema.ts
@@ -32,7 +32,6 @@ const TraineePersonalInfoSchema = new Schema<TraineePersonalInfo>(
     firstName: { type: String, required: true, index: true },
     lastName: { type: String, required: true, index: true },
     preferredName: { type: String, required: false, index: true, default: null },
-    imageUrl: { type: String, required: false, default: null },
     gender: { type: String, required: false, enum: Object.values(Gender), default: null },
     pronouns: { type: String, required: false, default: null },
     location: { type: String, required: false, default: null },
@@ -155,6 +154,8 @@ const TraineeEmploymentInfoSchema = new Schema<TraineeEmploymentInfo>(
 const TraineeSchema = new Schema<Trainee & WithMongoID>(
   {
     _id: { type: String, default: genId },
+    imageURL: { type: String, required: false, default: null },
+    thumbnailURL: { type: String, required: false, default: null },
     personalInfo: { type: TraineePersonalInfoSchema, required: true },
     contactInfo: { type: TraineeContactInfoSchema, required: true },
     educationInfo: {

--- a/server/src/services/StorageService.ts
+++ b/server/src/services/StorageService.ts
@@ -4,8 +4,13 @@ import stream from 'stream';
 
 export interface StorageServiceType {
   download(key: string): Promise<stream.Readable>;
-  upload(path: string, input: stream.Readable): Promise<void>;
+  upload(path: string, input: stream.Readable, accessControl: AccessControl): Promise<void>;
   delete(key: string): Promise<void>;
+}
+
+export enum AccessControl {
+  Public = 'public',
+  Private = 'private',
 }
 
 export class StorageService implements StorageServiceType {
@@ -37,13 +42,13 @@ export class StorageService implements StorageServiceType {
     });
   }
 
-  async upload(key: string, input: stream.Readable) {
+  async upload(key: string, input: stream.Readable, accessControl: AccessControl) {
     const upload = new Upload({
       client: this.s3Client,
       params: {
         Bucket: this.bucketName,
         Key: key,
-        ACL: 'private',
+        ACL: accessControl === AccessControl.Public ? 'public-read' : 'private',
         Body: input,
       },
     });


### PR DESCRIPTION
In this PR:

- All image uploads will be now public. This way we can directly use the S3 bucket URL in the client side. This improves the performance of the application and reduces load from the backend.
- Image upload will use a different name schemes
- Introduced two new fields in the trainee root object: `imageURL` and `thumbnailURL`
- Removed `imageUrl` field from `trainee.personalInfo`
- Removed GET /trainee/:id/profile-picture URL as it no longer need - we can now use the new imageURL property.
- Client changes are minimal