### PR TITLE
Standardized trainee profile navigation on the front end

### DIFF
--- a/client/src/components/SearchResultsList.tsx
+++ b/client/src/components/SearchResultsList.tsx
@@ -38,7 +38,7 @@ export const SearchResultsList = ({ isLoading, data }: SearchResultsListProps) =
             return (
               <ListItem disablePadding key={trainee.id}>
                 <Link
-                  to={`/trainee/${trainee.name.replace(/ /g, '-')}_${trainee.id}`}
+                  to={trainee.profileURL}
                   style={{
                     textDecoration: 'none',
                     color: 'inherit',

--- a/client/src/components/cohorts/CohortAccordion.tsx
+++ b/client/src/components/cohorts/CohortAccordion.tsx
@@ -13,7 +13,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import { TraineeAvatar } from '../cohorts/TraineeAvatar';
 
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Cohort, LearningStatus } from '../../models';
 import { SidebarJobPath, SidebarLearningStatus } from '..';
 import slackLogo from '../../assets/slack.png';
@@ -31,7 +31,6 @@ export interface CohortAccordionProps {
 export const CohortAccordion = ({ cohortInfo }: CohortAccordionProps) => {
   const expandFlag = cohortInfo.cohort !== null ? true : false;
 
-  const navigate = useNavigate();
   const headerStyle = {
     fontWeight: 'bold',
   };
@@ -67,8 +66,9 @@ export const CohortAccordion = ({ cohortInfo }: CohortAccordionProps) => {
                 <TableRow
                   key={trainee.id}
                   hover
-                  sx={{ '&:last-child td, &:last-child th': { border: 0 }, cursor: 'pointer' }}
-                  onClick={() => navigate(`/trainee/${trainee.displayName.replace(/ /g, '-')}_${trainee.id}`)}
+                  sx={{ '&:last-child td, &:last-child th': { border: 0 }, cursor: 'pointer', textDecoration: 'none' }}
+                  component={Link}
+                  to={trainee.profileURL}
                 >
                   <TableCell component="th" scope="row">
                     <TraineeAvatar imageURL={trainee.thumbnailURL ?? ''} altText={trainee.displayName}></TraineeAvatar>
@@ -122,7 +122,7 @@ export const CohortAccordion = ({ cohortInfo }: CohortAccordionProps) => {
   );
 };
 
-const convertToString = (value: Boolean | null | undefined) => {
+const convertToString = (value: boolean | null | undefined) => {
   if (value === null || value === undefined) {
     return '';
   }

--- a/client/src/models/Cohorts.ts
+++ b/client/src/models/Cohorts.ts
@@ -8,6 +8,7 @@ export interface Cohort {
 export interface TraineeSummary {
   id: string;
   displayName: string;
+  profileURL: string;
   thumbnailURL: string | null;
   location?: string;
   hasWorkPermit?: boolean;

--- a/client/src/models/Search.ts
+++ b/client/src/models/Search.ts
@@ -2,5 +2,6 @@ export interface SearchResult {
   id: number;
   name: string;
   thumbnail: string | null;
+  profileURL: string;
   cohort: number | null;
 }

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -147,6 +147,18 @@ paths:
                             name:
                               type: string
                               example: John Doe
+                            profileURL:
+                              type: string
+                              example: https://example.com/trainee/Isaac-Pagaca_HpOjvmwX
+                            thumbnailURL:
+                              type: string
+                              example: https://cdn.example.com/images/HpOjvmwX_thumb.jpeg
+                            cohort:
+                              type: number
+                              example: 52
+                            searchScore: 
+                              type: number
+                              example: 100
                       size:
                         type: integer
                         example: 45

--- a/server/src/controllers/CohortsController.ts
+++ b/server/src/controllers/CohortsController.ts
@@ -10,6 +10,7 @@ interface Cohort {
 interface TraineeSummary {
   id: string;
   displayName: string;
+  profileURL: string;
   thumbnailURL: string | null;
   location?: string;
   hasWorkPermit?: boolean;
@@ -63,6 +64,7 @@ export class CohortsController implements CohortsControllerType {
     return {
       id: trainee.id,
       displayName: trainee.displayName,
+      profileURL: trainee.profileURL,
       thumbnailURL: trainee.thumbnailURL ?? null,
       location: trainee.personalInfo.location,
       hasWorkPermit: trainee.personalInfo.hasWorkPermit,

--- a/server/src/controllers/SearchController.ts
+++ b/server/src/controllers/SearchController.ts
@@ -16,6 +16,7 @@ interface SearchResult {
   id: string;
   name: string;
   thumbnail: string | null;
+  profileURL: string;
   cohort: number | null;
   searchScore: number;
 }
@@ -78,6 +79,7 @@ export class SearchController implements SearchControllerType {
           name: `${trainee.displayName}`,
           thumbnail: trainee.thumbnailURL ?? null,
           cohort: trainee.educationInfo.currentCohort ?? null,
+          profileURL: trainee.profileURL,
           searchScore: this.calculateScore(trainee, keywords),
         };
       })


### PR DESCRIPTION
Created new profileURL property on the back-end to generate the link for react navigation. This will remove some of the duplicate logic on the front-end.

For cohorts page, I switched client navigation to use  `<Link to={profileURL}>` instead of programmatic navigate calls with `navigate()`