### PR TITLE
Increased minimum JWT token length from 16 to 32

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -5,7 +5,7 @@ DB_URL="mongodb://localhost:27017/dojo"
 BASE_URL="http://localhost:7777"
 
 # Authentication
-JWT_SECRET="<random string of at least 16 characters>"
+JWT_SECRET="<random string of at least 32 characters>"
 JWT_EXPIRATION_DAYS=1000
 GOOGLE_OAUTH_CLIENTID=xxxxx.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENTSECRET=secret

--- a/server/src/services/TokenService.ts
+++ b/server/src/services/TokenService.ts
@@ -12,8 +12,8 @@ export class TokenService implements TokenServiceType {
   private readonly ALGORITHM = 'HS512';
 
   constructor(secret: string, expirationInDays: number) {
-    if (!secret || secret.length < 16) {
-      throw new Error('JWT Secret is required');
+    if (!secret || secret.length < 32) {
+      throw new Error('JWT Secret must be at least 32 characters long for security');
     }
     this.secret = secret;
     this.expiration = `${expirationInDays}d`;


### PR DESCRIPTION
32 is the recommended minimum length to prevent brute force attacks on a JWT