### PR TITLE
Fix for issue #256 relating to the strike modal features.

### DIFF
--- a/client/src/components/education/StrikeDetailsModal.tsx
+++ b/client/src/components/education/StrikeDetailsModal.tsx
@@ -56,8 +56,7 @@ export const StrikeDetailsModal = ({
       setStrikeFields(strikeToEdit);
       setIsEditMode(true);
       return;
-    }
-    else {
+    } else {
       setIsEditMode(false);
     }
     resetForm();

--- a/client/src/components/education/StrikesComponent.tsx
+++ b/client/src/components/education/StrikesComponent.tsx
@@ -11,36 +11,36 @@ import { useState } from 'react';
 import { useTraineeProfileContext } from '../../hooks/useTraineeProfileContext';
 
 export const StrikesComponent = () => {
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false); //NOTE: bool for modal state
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const [modalError, setModalError] = useState<string>(''); //NOTE: string for modal error
-  const [strikeToEdit, setStrikeToEdit] = useState<Strike | null>(null); //NOTE: strike to edit state
-  const { traineeId } = useTraineeProfileContext(); //NOTE: collects id from context
-  const { mutate: addStrike, isLoading: addStrikeLoading } = useAddStrike(traineeId); //NOTE: how does mutate work? this is for the database
+  const [modalError, setModalError] = useState<string>('');
+  const [strikeToEdit, setStrikeToEdit] = useState<Strike | null>(null);
+  const { traineeId } = useTraineeProfileContext();
+  const { mutate: addStrike, isLoading: addStrikeLoading } = useAddStrike(traineeId);
   const { mutate: deleteStrike, isLoading: deleteStrikeLoading, error: deleteStrikeError } = useDeleteStrike(traineeId);
   const { mutate: editStrike, isLoading: editStrikeLoading } = useEditStrike(traineeId);
-  const { data: strikes, isLoading: strikesLoading, error: strikesError } = useGetStrikes(traineeId); //NOTE: gets strikes and state from database traineeId
-  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false); //NOTE: bool for confirmation dialog
+  const { data: strikes, isLoading: strikesLoading, error: strikesError } = useGetStrikes(traineeId);
+  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
 
-  const [idToDelete, setIdToDelete] = useState<string>(''); //TODO: how does this work
+  const [idToDelete, setIdToDelete] = useState<string>('');
   const queryClient = useQueryClient();
   const handleSuccess = () => {
     queryClient.invalidateQueries(['strikes', traineeId]);
     setIsModalOpen(false);
   };
 
-  const getErrorMessage = (error: Error | unknown) => {  //NOTE: gives the error message for the strikes list
+  const getErrorMessage = (error: Error | unknown) => {
     return (error as Error).message || 'Unknown error';
   };
 
-  const onClickEdit = (id: string) => { //NOTE: edits the id'ed strike
+  const onClickEdit = (id: string) => {
     const strike = strikes?.find((strike) => strike.id === id) || null;
 
     setStrikeToEdit(strike);
     setIsModalOpen(true);
   };
 
-  const onConfirmAdd = async (strike: Strike) => { //NOTE: add strike when confirmed
+  const onConfirmAdd = async (strike: Strike) => {
     addStrike(strike, {
       onSuccess: handleSuccess,
       onError: (e) => {
@@ -49,7 +49,7 @@ export const StrikesComponent = () => {
     });
   };
 
-  const onConfirmEdit = (strike: Strike) => { //NOTE: push edit when confirmed
+  const onConfirmEdit = (strike: Strike) => {
     editStrike(strike, {
       onSuccess: handleSuccess,
       onError: (e) => {
@@ -58,7 +58,7 @@ export const StrikesComponent = () => {
     });
   };
 
-  const onClickDelete = (id: string) => { //NOTE: Shows confirmation button
+  const onClickDelete = (id: string) => {
     setIdToDelete(id);
     setIsConfirmationDialogOpen(true);
   };
@@ -66,7 +66,7 @@ export const StrikesComponent = () => {
   /**
    * Function to enable adding strikes.
    */
-  const onClickAdd = () => { //TODO: Fix this issue
+  const onClickAdd = () => {
     setStrikeToEdit(null);
     setIsModalOpen(true);
   };

--- a/client/src/components/education/StrikesList.tsx
+++ b/client/src/components/education/StrikesList.tsx
@@ -7,13 +7,13 @@ import { Strike } from '../../models';
 import { formatDateForDisplay } from '../../helpers/dateHelper';
 import MarkdownText from '../shared/MarkdownText';
 
-interface StrikesListProps { //NOTE: seems to hold strikes list
+interface StrikesListProps {
   strikes: Strike[];
   onClickEdit: (id: string) => void;
   onClickDelete: (id: string) => void;
 }
 
-export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, onClickDelete }) => { //NOTE: so this is making sure that strikes list is a react functional component with strikeslist props
+export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, onClickDelete }) => {
   /**
    * Formats the strike reason to a readable format
    * with the first letter capitalized
@@ -21,17 +21,16 @@ export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, 
    * @returns The formatted strike reason
    */
   const formatStrikeReason = (reason: string): string => {
-    return reason.split('-').join(' ').charAt(0).toUpperCase() + reason.split('-').join(' ').slice(1).toLowerCase(); //NOTE: formatter for the comment
+    return reason.split('-').join(' ').charAt(0).toUpperCase() + reason.split('-').join(' ').slice(1).toLowerCase();
   };
 
-  const handleEdit = (id: string) => { //NOTE: what to do for edit and delete which are on the side of each strike
+  const handleEdit = (id: string) => {
     onClickEdit(id);
   };
   const handleDelete = (id: string) => {
     onClickDelete(id);
   };
 
-  //NOTE: render how the actions look and these are two buttons that call either edit or delete.
   const renderActions = (id: string) => {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: 1 }}>
@@ -45,7 +44,6 @@ export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, 
     );
   };
 
-  //NOTE: the return of the component I assume that here is where the const render actions will be also called.
   return (
     <List
       sx={{
@@ -56,13 +54,13 @@ export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, 
         scrollbarWidth: 'thin',
       }}
     >
-      {strikes.length === 0 ? ( //NOTE: add all found elements in the list or none
+      {strikes.length === 0 ? (
         <Typography variant="body1" color="#CCCCCC" padding="16px">
           No strikes found
         </Typography>
       ) : (
         strikes.map((strike: Strike, index: number) => {
-          return ( //NOTE: the boxes are keyed so they are found again when needed
+          return (
             <Box key={strike.id}>
               <ListItem
                 alignItems="flex-start"
@@ -96,7 +94,11 @@ export const StrikesList: React.FC<StrikesListProps> = ({ strikes, onClickEdit, 
                       <Typography sx={{ paddingRight: 2 }}>{formatDateForDisplay(strike.date)}</Typography>
                     </Box>
                   }
-                  secondary={<Box mt={-2}><MarkdownText>{strike.comments}</MarkdownText></Box>}
+                  secondary={
+                    <Box mt={-2}>
+                      <MarkdownText>{strike.comments}</MarkdownText>
+                    </Box>
+                  }
                 />
                 {renderActions(strike.id)}
               </ListItem>


### PR DESCRIPTION
### Fix for issue #256 relating to the strike modal features.
For #256 , the solution is to pass a flag to let the strike modal know that editing is different than adding a strike. This is done by passing a null value for the `strikeToEdit` property. Furthermore, using the `resetForm()` function cleans up the form after adding a new strike. 

Finally, minor margin changes were added for a better fitting list.