### PR TITLE
Fixed an issue with missing number casting in the import data script

### DIFF
--- a/server/scripts/import-data/import-data.ts
+++ b/server/scripts/import-data/import-data.ts
@@ -4,6 +4,10 @@
 import fs from 'fs';
 import { parse } from 'csv-parse/sync';
 
+// Config
+const URL = 'http://localhost:7777/api/trainees';
+const TOKEN = '<TOKEN>';
+
 const replaceBoolean = (str: string) => {
   if (!str.trim()) {
     return null;
@@ -46,8 +50,8 @@ const extractData = (data: string) => {
         linkedin: handleString(row['LinkedIn Profile URL']),
       },
       educationInfo: {
-        startCohort: row['Start Cohort*'],
-        currentCohort: row['Current Cohort'],
+        startCohort: Number(row['Start Cohort*']),
+        currentCohort: Number(row['Current Cohort']),
         learningStatus: handleString(row['Learning Status*']),
         startDate: handleString(row['Start Date']),
         graduationDate: handleString(row['Graduation Date']),
@@ -87,9 +91,6 @@ const main = async () => {
 };
 
 const postTrainee = async (trainee: any): Promise<string> => {
-  const URL = 'http://localhost:7777/api/trainees';
-  const TOKEN = '<TOKEN>';
-
   let response: any, body: any;
   try {
     response = await fetch(URL, {


### PR DESCRIPTION
This caused the POST /trainee API call to fail because the cohort number was from a string type and on the backend, it expects a number.