### PR TITLE
Removed full path from profile URL

### DIFF
--- a/client/src/features/cohorts/Cohorts.ts
+++ b/client/src/features/cohorts/Cohorts.ts
@@ -8,7 +8,7 @@ export interface Cohort {
 export interface TraineeSummary {
   id: string;
   displayName: string;
-  profileURL: string;
+  profilePath: string;
   thumbnailURL: string | null;
   location?: string;
   hasWorkPermit?: boolean;

--- a/client/src/features/cohorts/components/CohortAccordion.tsx
+++ b/client/src/features/cohorts/components/CohortAccordion.tsx
@@ -72,7 +72,7 @@ const CohortAccordion = ({ cohortInfo }: CohortAccordionProps) => {
                   hover
                   sx={{ '&:last-child td, &:last-child th': { border: 0 }, cursor: 'pointer', textDecoration: 'none' }}
                   component={Link}
-                  to={trainee.profileURL}
+                  to={trainee.profilePath}
                 >
                   <TableCell component="th" scope="row">
                     <TraineeAvatar imageURL={trainee.thumbnailURL ?? ''} altText={trainee.displayName}></TraineeAvatar>

--- a/client/src/features/search/Search.ts
+++ b/client/src/features/search/Search.ts
@@ -2,6 +2,6 @@ export interface SearchResult {
   id: number;
   name: string;
   thumbnail: string | null;
-  profileURL: string;
+  profilePath: string;
   cohort: number | null;
 }

--- a/client/src/features/search/components/SearchResultsList.tsx
+++ b/client/src/features/search/components/SearchResultsList.tsx
@@ -39,7 +39,7 @@ const SearchResultsList = ({ isLoading, data }: SearchResultsListProps) => {
             return (
               <ListItem disablePadding key={trainee.id}>
                 <Link
-                  to={trainee.profileURL}
+                  to={trainee.profilePath}
                   style={{
                     textDecoration: 'none',
                     color: 'inherit',

--- a/server/api.yaml
+++ b/server/api.yaml
@@ -149,9 +149,9 @@ paths:
                             name:
                               type: string
                               example: John Doe
-                            profileURL:
+                            profilePath:
                               type: string
-                              example: https://example.com/trainee/Isaac-Pagaca_HpOjvmwX
+                              example: /trainee/Isaac-Pagaca_HpOjvmwX
                             thumbnailURL:
                               type: string
                               example: https://cdn.example.com/images/HpOjvmwX_thumb.jpeg
@@ -1280,9 +1280,9 @@ components:
         displayName:
           type: string
           example: Johnny Doe
-        profileURL:
+        profilePath:
           type: string
-          example: https://example.com/trainee/Isaac-Pagaca_HpOjvmwX
+          example: /trainee/Isaac-Pagaca_HpOjvmwX
         imageURL:
           type: string
           example: https://cdn.example.com/images/profile/HpOjvmwX.jpeg

--- a/server/scripts/setup/generators/traineeGenerator.ts
+++ b/server/scripts/setup/generators/traineeGenerator.ts
@@ -39,7 +39,7 @@ export const generateTrainee = (): Trainee => {
     displayName: '',
     createdAt: new Date(),
     updatedAt: new Date(),
-    profileURL: '',
+    profilePath: '',
     personalInfo,
     contactInfo,
     educationInfo,

--- a/server/src/controllers/CohortsController.ts
+++ b/server/src/controllers/CohortsController.ts
@@ -10,7 +10,7 @@ interface Cohort {
 interface TraineeSummary {
   id: string;
   displayName: string;
-  profileURL: string;
+  profilePath: string;
   thumbnailURL: string | null;
   location?: string;
   hasWorkPermit?: boolean;
@@ -65,7 +65,7 @@ export class CohortsController implements CohortsControllerType {
     return {
       id: trainee.id,
       displayName: trainee.displayName,
-      profileURL: trainee.profileURL,
+      profilePath: trainee.profilePath,
       thumbnailURL: trainee.thumbnailURL ?? null,
       location: trainee.personalInfo.location,
       hasWorkPermit: trainee.personalInfo.hasWorkPermit,

--- a/server/src/controllers/SearchController.ts
+++ b/server/src/controllers/SearchController.ts
@@ -16,7 +16,7 @@ interface SearchResult {
   id: string;
   name: string;
   thumbnail: string | null;
-  profileURL: string;
+  profilePath: string;
   cohort: number | null;
   searchScore: number;
 }
@@ -70,7 +70,6 @@ export class SearchController implements SearchControllerType {
     // In an ideal scenario we should have a complex query to filter on the DB side.
     // However, because our dataset is not large, we can get away with this for now.
     const trainees = await this.traineesRepository.getAllTrainees();
-
     // Process all trainees, calculate the search score and return the top N results
     return trainees
       .map((trainee) => {
@@ -79,7 +78,7 @@ export class SearchController implements SearchControllerType {
           name: `${trainee.displayName}`,
           thumbnail: trainee.thumbnailURL ?? null,
           cohort: trainee.educationInfo.currentCohort ?? null,
-          profileURL: trainee.profileURL,
+          profilePath: trainee.profilePath,
           searchScore: this.calculateScore(trainee, keywords),
         };
       })

--- a/server/src/models/Trainee.ts
+++ b/server/src/models/Trainee.ts
@@ -90,7 +90,7 @@ export interface Trainee {
   readonly id: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
-  profileURL: string;
+  profilePath: string;
   displayName: string;
   imageURL?: string;
   thumbnailURL?: string;
@@ -175,9 +175,15 @@ export const getDisplayName = (trainee: Trainee): string => {
   return `${name} ${lastName}`;
 };
 
-export const getProfileURL = (trainee: Trainee): string => {
+export const getProfilePath = (trainee: Trainee): string => {
   const normalizedName = removeAccents(getDisplayName(trainee).toLowerCase()).replaceAll(/\s/g, '-');
   return `/trainee/${normalizedName}_${trainee.id}`;
+};
+
+export const getProfileURL = (trainee: Trainee): string => {
+  const url = new URL(process.env.BASE_URL ?? 'https://localhost');
+  url.pathname = getProfilePath(trainee);
+  return url.toString();
 };
 
 // Validations

--- a/server/src/schemas/TraineeSchema.ts
+++ b/server/src/schemas/TraineeSchema.ts
@@ -23,7 +23,7 @@ import {
   TraineeEmploymentInfo,
   TraineePersonalInfo,
   getDisplayName,
-  getProfileURL,
+  getProfilePath,
 } from '../models';
 import { WithMongoID, jsonFormatting } from '../utils/database';
 
@@ -185,8 +185,8 @@ TraineeSchema.virtual('displayName').get(function () {
   return getDisplayName(this as Trainee);
 });
 
-TraineeSchema.virtual('profileURL').get(function () {
-  return getProfileURL(this as Trainee);
+TraineeSchema.virtual('profilePath').get(function () {
+  return getProfilePath(this as Trainee);
 });
 
 TraineeSchema.set('toJSON', jsonFormatting);


### PR DESCRIPTION
This caused an issue with unwanted redirection when navigating to a trainee profile.

- Replaced `profileURL` with `profilePath` property. 
- The profile path returns absolute path for client side navigation (example: `/trainee/first-last_id`)
- Slack notifications still require the full URL including the hostname. This was addressed by creating new `getProfileURL` method that will add the host to the trainee path