### PR TITLE
To replace mui loadingbutton with standard button component

### DIFF
--- a/client/src/components/ConfirmationDialog.tsx
+++ b/client/src/components/ConfirmationDialog.tsx
@@ -1,7 +1,5 @@
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 
-import { LoadingButton } from '@mui/lab';
-
 interface ConfirmationDialogProps {
   isOpen: boolean;
   title: string;
@@ -31,9 +29,9 @@ export const ConfirmationDialog = ({
         <Button disabled={isLoading} onClick={onCancel}>
           Cancel
         </Button>
-        <LoadingButton disabled={isLoading} onClick={onConfirm} variant="contained" color="error">
+        <Button disabled={isLoading} loading={isLoading} onClick={onConfirm} variant="contained" color="error">
           {confirmButtonText}
-        </LoadingButton>
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/client/src/features/trainee-profile/education/strikes/components/StrikeDetailsModal.tsx
+++ b/client/src/features/trainee-profile/education/strikes/components/StrikeDetailsModal.tsx
@@ -16,7 +16,6 @@ import {
 } from '@mui/material';
 import { Strike, StrikeReason } from '../models/strike';
 
-import { LoadingButton } from '@mui/lab';
 import { formatDate } from '../../../utils/dateHelper';
 import { useState } from 'react';
 
@@ -199,9 +198,9 @@ export const StrikeDetailsModal = ({
             <Button variant="outlined" disabled={isLoading} onClick={handleClose} fullWidth>
               Cancel
             </Button>
-            <LoadingButton loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
+            <Button loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
               Save
-            </LoadingButton>
+            </Button>
           </Box>
         </Box>
       </Fade>

--- a/client/src/features/trainee-profile/education/tests/TestDetailsModal.tsx
+++ b/client/src/features/trainee-profile/education/tests/TestDetailsModal.tsx
@@ -16,7 +16,6 @@ import {
 } from '@mui/material';
 import { Test, TestResult, TestType } from '../../../../data/types/Trainee';
 
-import { LoadingButton } from '@mui/lab';
 import { formatDate } from '../../utils/dateHelper';
 import { useState } from 'react';
 
@@ -219,9 +218,9 @@ export const TestDetailsModal = ({
             <Button variant="outlined" disabled={isLoading} onClick={handleClose} fullWidth>
               Cancel
             </Button>
-            <LoadingButton loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
+            <Button loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
               Save
-            </LoadingButton>
+            </Button>
           </Box>
         </Box>
       </Fade>

--- a/client/src/features/trainee-profile/employment/history/EmploymentDetailsModal.tsx
+++ b/client/src/features/trainee-profile/employment/history/EmploymentDetailsModal.tsx
@@ -20,7 +20,6 @@ import {
   Typography,
 } from '@mui/material';
 import { formatDate } from '../../utils/dateHelper';
-import { LoadingButton } from '@mui/lab';
 
 interface EmploymentDetailsModalProps {
   isOpen: boolean;
@@ -281,9 +280,9 @@ export const EmploymentDetailsModal = ({
             <Button variant="outlined" disabled={isLoading} onClick={handleClose} fullWidth>
               Cancel
             </Button>
-            <LoadingButton loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
+            <Button loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm} fullWidth>
               Save
-            </LoadingButton>
+            </Button>
           </Box>
         </Box>
       </Fade>

--- a/client/src/features/trainee-profile/interactions/components/AddNewInteractionComponent.tsx
+++ b/client/src/features/trainee-profile/interactions/components/AddNewInteractionComponent.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Paper, SelectChangeEvent, Typography } from '@mui/material';
+import { Alert, Box, Button, Paper, SelectChangeEvent, Typography } from '@mui/material';
 import React, { useState } from 'react';
 
 import FormDateTextField from './FormDateTextField';
@@ -6,7 +6,6 @@ import FormSelect from './FormSelect';
 import FormTextField from './FormTextField';
 import { Interaction } from '../Interactions';
 import { InteractionType } from '../Interactions';
-import { LoadingButton } from '@mui/lab';
 import { useAddInteraction } from '../data/interaction-queries';
 
 const types = Object.values(InteractionType);
@@ -110,7 +109,7 @@ const AddNewInteractionComponent: React.FC<AddNewInteractionComponentProps> = ({
           required
         />
 
-        <LoadingButton
+        <Button
           sx={{ alignSelf: 'flex-start' }}
           variant="outlined"
           color="primary"
@@ -119,7 +118,7 @@ const AddNewInteractionComponent: React.FC<AddNewInteractionComponentProps> = ({
           disabled={isPending}
         >
           Add
-        </LoadingButton>
+        </Button>
         {error && <Alert severity="error">{error}</Alert>}
       </Box>
     </Paper>

--- a/client/src/features/trainee-profile/interactions/components/InteractionDetailsModal.tsx
+++ b/client/src/features/trainee-profile/interactions/components/InteractionDetailsModal.tsx
@@ -15,7 +15,6 @@ import { Interaction, InteractionType } from '../Interactions';
 
 import FormSelect from './FormSelect';
 import FormTextField from './FormTextField';
-import { LoadingButton } from '@mui/lab';
 import { formatDate } from '../../utils/dateHelper';
 import { useState } from 'react';
 
@@ -200,9 +199,9 @@ export const InteractionDetailsModal = ({
             <Button variant="outlined" disabled={isLoading} onClick={handleClose}>
               Cancel
             </Button>
-            <LoadingButton loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm}>
+            <Button loading={isLoading} disabled={isLoading} variant="contained" onClick={onConfirm}>
               {isEditMode ? 'Save' : 'Add'}
-            </LoadingButton>
+            </Button>
           </Box>
         </Box>
       </Fade>

--- a/client/src/features/trainee-profile/profile/components/EditSaveButton.tsx
+++ b/client/src/features/trainee-profile/profile/components/EditSaveButton.tsx
@@ -1,4 +1,3 @@
-import { LoadingButton } from '@mui/lab';
 import { Box, Button } from '@mui/material';
 
 export interface EditSaveButtonProps {
@@ -16,9 +15,9 @@ export const EditSaveButton = ({ isEditMode, isLoading, onCancel, onClickEditBut
           Cancel
         </Button>
       )}
-      <LoadingButton variant="contained" loading={isLoading} onClick={onClickEditButton}>
+      <Button variant="contained" loading={isLoading} onClick={onClickEditButton}>
         {isEditMode ? 'Save' : 'Edit'}
-      </LoadingButton>
+      </Button>
     </Box>
   );
 };

--- a/client/src/theme/theme.ts
+++ b/client/src/theme/theme.ts
@@ -1,5 +1,3 @@
-import '@mui/lab/themeAugmentation';
-
 import { createTheme } from '@mui/material';
 
 declare module '@mui/material/styles' {


### PR DESCRIPTION
This PR is to migrates all usages of LoadingButton from @mui/lab to the standard Button component from @mui/material.

closes #314 