### PR TITLE
Fixed an issue where an image skeleton is shown if the image url is null

### DIFF
--- a/client/src/features/cohorts/components/TraineeAvatar.tsx
+++ b/client/src/features/cohorts/components/TraineeAvatar.tsx
@@ -11,7 +11,7 @@ export const TraineeAvatar = ({ imageURL, altText }: TraineeAvatarProps) => {
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  if (isError) {
+  if (imageURL.trim().length === 0 || isError) {
     return <Avatar sx={size} alt={altText} variant="square"></Avatar>;
   }
 
@@ -25,7 +25,7 @@ export const TraineeAvatar = ({ imageURL, altText }: TraineeAvatarProps) => {
         style={{
           width: `${isLoading ? 0 : size.width}px`,
           height: `${isLoading ? 0 : size.height}px`,
-          display: isLoading ? 'block' : 'block',
+          display: 'block',
         }}
         onError={() => {
           setIsLoading(false);


### PR DESCRIPTION
Correct behavior is to show the default avatar image just like the on error 

Before:
<img width="615" height="248" alt="image" src="https://github.com/user-attachments/assets/89562900-8052-4281-8e55-f3354fb79360" />


After:
<img width="615" height="248" alt="image" src="https://github.com/user-attachments/assets/6eb93e97-bb33-4ce4-a03e-bdb302079819" />
